### PR TITLE
fix repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ export VALUES_FILE=./my_values.yaml   # your values file
 
 helm install \
   "${RELEASE_NAME}" \
-  odenio/pgpool-cloudsql \
+  pgpool-cloudsql/pgpool-cloudsql \
   --atomic \
   --timeout=5m0s \
   --namespace "${NAMESPACE}" \


### PR DESCRIPTION
It's an simple correcting of README.md.

In 'Step One', the command add a repo 'pgpool-cloudsql'.
but in 'Step Two', command are trying to install 'odenio/pgpool-cloudsql'.

It occures error.